### PR TITLE
(feat) CLOUD-70 | Add matrix to build Dockerfiles in sub directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Local files from gitlab-ci-local runs
+.gitlab-ci-local
+*.env
+gitlab-ci
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,25 @@
 include:
   - project: earthscope/infrastructure/gitlab-ci
-    ref: "latest"
-    file: project-template-image.yml
+    ref: "$GITLAB_CI_LIB_VERSION"
+    file:
+      - project-template-image-matrix.yml
+    rules:
+      - exists:
+          - gitlab-ci
+        when: never
+      - when: always
+  - local: gitlab-ci/project-template-image-matrix.yml
+    rules:
+      - exists:
+          - gitlab-ci
+        when: always
+      - when: never
+
+.images_matrix:
+  - DOCKERFILE_RELPATH: "geolab-default"
+  - DOCKERFILE_RELPATH: "mspass_shortcourse"
+  - DOCKERFILE_RELPATH: "mt_shortcourse"
 
 variables:
   CONTAINER_REGISTRY_PLATFORM: "AWS-PUB"
+  DOCKERFILE_RELPATH_IS_IMAGE_NAME: "true"


### PR DESCRIPTION
This MR adds the GitLab pipeline code to build project sub directories into separate container images. An example image being built:

https://gallery.ecr.aws/earthscope-dev/geolab/geolab-default