### PR TITLE
chore: pull up earthscope-sdk/cli

### DIFF
--- a/geolab-default/environment.yml
+++ b/geolab-default/environment.yml
@@ -12,8 +12,8 @@ dependencies:
     - awswrangler
     - cvxpy
     - dascore
-    - earthscope-sdk==1.1.0
-    - earthscope-cli==1.0.0
+    - earthscope-sdk==1.2.0b0
+    - earthscope-cli==1.0.1
     - earthscopestraintools
     - hypoinvpy
     - gnssrefl


### PR DESCRIPTION
Pull up `earthscope-sdk` to `1.2.0b0`
Pull up `earthscope-cli` to `1.0.1`